### PR TITLE
feat: rank-weighted Elo system

### DIFF
--- a/components/matches/pending-match-card.tsx
+++ b/components/matches/pending-match-card.tsx
@@ -87,7 +87,7 @@ export function PendingMatchCard({
                 isWinner ? "text-green-400" : "text-red-400"
               }`}
             >
-              {isWinner ? "+" : "-"}{eloChange}
+              ~{isWinner ? "+" : "-"}{eloChange}
             </span>
             <span className="text-xs text-muted-foreground">
               ({currentElo} → {newElo})

--- a/components/matches/record-match-form.tsx
+++ b/components/matches/record-match-form.tsx
@@ -31,9 +31,22 @@ export function RecordMatchForm({
   const winner = didWin === true ? currentUser : opponent;
   const loser = didWin === true ? opponent : currentUser;
 
+  // Derive ranks from sorted players array (already sorted by elo_rating DESC)
+  const winnerRank = winner
+    ? players.findIndex((p) => p.id === winner.id) + 1
+    : 0;
+  const loserRank = loser
+    ? players.findIndex((p) => p.id === loser.id) + 1
+    : 0;
+  const totalPlayers = players.length;
+
   const preview =
     winner && loser && didWin !== null
-      ? calculateEloChange(winner.elo_rating, loser.elo_rating)
+      ? calculateEloChange(winner.elo_rating, loser.elo_rating, {
+          winnerRank,
+          loserRank,
+          totalPlayers,
+        })
       : null;
 
   return (
@@ -87,9 +100,14 @@ export function RecordMatchForm({
 
       {preview !== null && winner && loser && (
         <div className="rounded-xl border border-border bg-card p-4 space-y-2">
-          <p className="text-sm font-medium text-muted-foreground">
-            Elo Preview
-          </p>
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-medium text-muted-foreground">
+              Elo Preview
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Rank #{winnerRank} vs #{loserRank}
+            </p>
+          </div>
           <div className="flex justify-between text-sm">
             <span>{winner.display_name || winner.username}</span>
             <span className="text-green-400 tabular-nums font-medium">

--- a/components/matches/record-match-modal.tsx
+++ b/components/matches/record-match-modal.tsx
@@ -29,14 +29,23 @@ function EloPreview({
   winner,
   loser,
   change,
+  winnerRank,
+  loserRank,
 }: {
   winner: Profile;
   loser: Profile;
   change: number;
+  winnerRank: number;
+  loserRank: number;
 }) {
   return (
     <div className="rounded-xl border border-border bg-muted/50 p-4 space-y-2">
-      <p className="text-sm font-medium text-muted-foreground">Elo Preview</p>
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium text-muted-foreground">Elo Preview</p>
+        <p className="text-xs text-muted-foreground">
+          Rank #{winnerRank} vs #{loserRank}
+        </p>
+      </div>
       <div className="flex justify-between text-sm">
         <span>{winner.display_name || winner.username}</span>
         <span className="text-green-400 tabular-nums font-medium">
@@ -78,9 +87,22 @@ function RecordMatchContent({
   const winner = didWin === true ? currentUser : opponent;
   const loser = didWin === true ? opponent : currentUser;
 
+  // Derive ranks from sorted players array (already sorted by elo_rating DESC)
+  const winnerRank = winner
+    ? players.findIndex((p) => p.id === winner.id) + 1
+    : 0;
+  const loserRank = loser
+    ? players.findIndex((p) => p.id === loser.id) + 1
+    : 0;
+  const totalPlayers = players.length;
+
   const preview =
     winner && loser && didWin !== null
-      ? calculateEloChange(winner.elo_rating, loser.elo_rating)
+      ? calculateEloChange(winner.elo_rating, loser.elo_rating, {
+          winnerRank,
+          loserRank,
+          totalPlayers,
+        })
       : null;
 
   async function handleSubmit(formData: FormData) {
@@ -143,7 +165,7 @@ function RecordMatchContent({
       </div>
 
       {preview !== null && winner && loser && (
-        <EloPreview winner={winner} loser={loser} change={preview} />
+        <EloPreview winner={winner} loser={loser} change={preview} winnerRank={winnerRank} loserRank={loserRank} />
       )}
 
       <Button

--- a/lib/elo.ts
+++ b/lib/elo.ts
@@ -2,6 +2,17 @@ export const K_FACTOR = 32;
 export const STARTING_RATING = 1200;
 export const MINIMUM_RATING = 100;
 
+// Rank-weighted K-factor constants
+export const RANK_SCALE = 0.5;
+export const K_MIN_MULTIPLIER = 0.5;
+export const K_MAX_MULTIPLIER = 1.5;
+
+export type RankInfo = {
+  winnerRank: number;
+  loserRank: number;
+  totalPlayers: number;
+};
+
 /**
  * Calculate expected score (probability of winning) for player A against player B.
  */
@@ -10,15 +21,43 @@ export function expectedScore(ratingA: number, ratingB: number): number {
 }
 
 /**
+ * Calculate the K-factor multiplier based on rank positions.
+ *
+ * When the higher-ranked player wins (expected), multiplier < 1 (less Elo exchanged).
+ * When the lower-ranked player wins (upset), multiplier > 1 (more Elo exchanged).
+ * When adjacent ranks play, multiplier ~ 1 (normal Elo exchange).
+ */
+export function calculateRankMultiplier(
+  winnerRank: number,
+  loserRank: number,
+  totalPlayers: number
+): number {
+  if (totalPlayers <= 1) return 1;
+  const rankDifference = winnerRank - loserRank;
+  const rawFactor = 1 + (rankDifference / totalPlayers) * RANK_SCALE;
+  return Math.min(K_MAX_MULTIPLIER, Math.max(K_MIN_MULTIPLIER, rawFactor));
+}
+
+/**
  * Calculate Elo change after a match.
  * Returns a positive integer — winner gains this, loser loses it.
+ * If rankInfo is provided, K-factor is scaled by rank proximity.
  */
 export function calculateEloChange(
   winnerRating: number,
-  loserRating: number
+  loserRating: number,
+  rankInfo?: RankInfo
 ): number {
   const expected = expectedScore(winnerRating, loserRating);
-  return Math.max(1, Math.round(K_FACTOR * (1 - expected)));
+  const multiplier = rankInfo
+    ? calculateRankMultiplier(
+        rankInfo.winnerRank,
+        rankInfo.loserRank,
+        rankInfo.totalPlayers
+      )
+    : 1;
+  const adjustedK = K_FACTOR * multiplier;
+  return Math.max(1, Math.round(adjustedK * (1 - expected)));
 }
 
 /**
@@ -26,13 +65,14 @@ export function calculateEloChange(
  */
 export function applyMatchResult(
   winnerRating: number,
-  loserRating: number
+  loserRating: number,
+  rankInfo?: RankInfo
 ): {
   newWinnerRating: number;
   newLoserRating: number;
   eloChange: number;
 } {
-  const eloChange = calculateEloChange(winnerRating, loserRating);
+  const eloChange = calculateEloChange(winnerRating, loserRating, rankInfo);
   return {
     newWinnerRating: winnerRating + eloChange,
     newLoserRating: Math.max(MINIMUM_RATING, loserRating - eloChange),

--- a/supabase/migrations/003_rank_weighted_elo.sql
+++ b/supabase/migrations/003_rank_weighted_elo.sql
@@ -1,0 +1,261 @@
+-- ATP Rank: Rank-Weighted Elo System
+-- Elo changes now depend on leaderboard position, not just rating difference.
+-- Upsets (lower-ranked beating higher-ranked) are rewarded more.
+-- Expected wins (higher-ranked beating lower-ranked) are rewarded less.
+--
+-- Run this migration in your Supabase SQL editor (DO NOT run via CLI).
+
+-- ============================================
+-- HELPER: GET PLAYER RANK
+-- ============================================
+-- Returns a player's 1-based rank and total player count.
+
+create or replace function public.get_player_rank(p_player_id uuid)
+returns table(rank integer, total_players integer) as $$
+begin
+  return query
+  with ranked as (
+    select id, rank() over (order by elo_rating desc) as player_rank,
+           count(*) over () as total
+    from public.profiles
+  )
+  select ranked.player_rank::integer, ranked.total::integer
+  from ranked
+  where ranked.id = p_player_id;
+end;
+$$ language plpgsql stable security definer;
+
+-- ============================================
+-- REPLACE RECORD_MATCH RPC (rank-weighted)
+-- ============================================
+-- Used for tournament matches (immediate Elo application).
+-- Same signature — no app code changes needed.
+
+create or replace function public.record_match(
+  p_winner_id uuid,
+  p_loser_id uuid,
+  p_recorded_by uuid,
+  p_challenge_id uuid default null,
+  p_tournament_match_id uuid default null
+) returns uuid as $$
+declare
+  v_winner_elo integer;
+  v_loser_elo integer;
+  v_winner_rank integer;
+  v_loser_rank integer;
+  v_total integer;
+  v_rank_diff integer;
+  v_raw_factor float;
+  v_multiplier float;
+  v_adjusted_k float;
+  v_expected float;
+  v_change integer;
+  v_match_id uuid;
+begin
+  -- Lock and get current ratings
+  select elo_rating into v_winner_elo from public.profiles where id = p_winner_id for update;
+  select elo_rating into v_loser_elo from public.profiles where id = p_loser_id for update;
+
+  -- Get ranks (computed from current elo_rating ordering)
+  select r.rank, r.total_players into v_winner_rank, v_total
+    from public.get_player_rank(p_winner_id) r;
+  select r.rank into v_loser_rank
+    from public.get_player_rank(p_loser_id) r;
+
+  -- Rank-weighted K-factor: RANK_SCALE=0.5, K_MIN_MULT=0.5, K_MAX_MULT=1.5
+  v_rank_diff := v_winner_rank - v_loser_rank;
+  v_raw_factor := 1.0 + (v_rank_diff::float / greatest(v_total, 1)::float) * 0.5;
+  v_multiplier := least(1.5, greatest(0.5, v_raw_factor));
+  v_adjusted_k := 32.0 * v_multiplier;
+
+  -- Elo calculation
+  v_expected := 1.0 / (1.0 + power(10.0, (v_loser_elo - v_winner_elo)::float / 400.0));
+  v_change := greatest(1, round(v_adjusted_k * (1.0 - v_expected)));
+
+  -- Insert match record
+  insert into public.matches (winner_id, loser_id, winner_elo_before, loser_elo_before, elo_change, recorded_by, challenge_id, tournament_match_id)
+  values (p_winner_id, p_loser_id, v_winner_elo, v_loser_elo, v_change, p_recorded_by, p_challenge_id, p_tournament_match_id)
+  returning id into v_match_id;
+
+  -- Update winner
+  update public.profiles
+  set elo_rating = elo_rating + v_change, wins = wins + 1, updated_at = now()
+  where id = p_winner_id;
+
+  -- Update loser (floor at 100)
+  update public.profiles
+  set elo_rating = greatest(100, elo_rating - v_change), losses = losses + 1, updated_at = now()
+  where id = p_loser_id;
+
+  -- Complete challenge if applicable
+  if p_challenge_id is not null then
+    update public.challenges
+    set status = 'completed', completed_at = now()
+    where id = p_challenge_id;
+  end if;
+
+  -- Update tournament match if applicable
+  if p_tournament_match_id is not null then
+    update public.tournament_matches
+    set winner_id = p_winner_id, match_id = v_match_id
+    where id = p_tournament_match_id;
+  end if;
+
+  return v_match_id;
+end;
+$$ language plpgsql security definer;
+
+-- ============================================
+-- REPLACE CREATE_PENDING_MATCH RPC (rank-weighted)
+-- ============================================
+-- Preview estimate stored on the match; real calculation at confirm time.
+
+create or replace function public.create_pending_match(
+  p_winner_id uuid,
+  p_loser_id uuid,
+  p_recorded_by uuid,
+  p_challenge_id uuid default null
+) returns uuid as $$
+declare
+  v_winner_elo integer;
+  v_loser_elo integer;
+  v_winner_rank integer;
+  v_loser_rank integer;
+  v_total integer;
+  v_rank_diff integer;
+  v_raw_factor float;
+  v_multiplier float;
+  v_adjusted_k float;
+  v_expected float;
+  v_change integer;
+  v_match_id uuid;
+begin
+  -- Get current ratings (no lock needed, just reading for preview)
+  select elo_rating into v_winner_elo from public.profiles where id = p_winner_id;
+  select elo_rating into v_loser_elo from public.profiles where id = p_loser_id;
+
+  -- Get ranks
+  select r.rank, r.total_players into v_winner_rank, v_total
+    from public.get_player_rank(p_winner_id) r;
+  select r.rank into v_loser_rank
+    from public.get_player_rank(p_loser_id) r;
+
+  -- Rank-weighted K-factor
+  v_rank_diff := v_winner_rank - v_loser_rank;
+  v_raw_factor := 1.0 + (v_rank_diff::float / greatest(v_total, 1)::float) * 0.5;
+  v_multiplier := least(1.5, greatest(0.5, v_raw_factor));
+  v_adjusted_k := 32.0 * v_multiplier;
+
+  -- Elo calculation (preview estimate)
+  v_expected := 1.0 / (1.0 + power(10.0, (v_loser_elo - v_winner_elo)::float / 400.0));
+  v_change := greatest(1, round(v_adjusted_k * (1.0 - v_expected)));
+
+  -- Insert match record with pending status
+  insert into public.matches (
+    winner_id, loser_id, winner_elo_before, loser_elo_before,
+    elo_change, recorded_by, challenge_id, status
+  )
+  values (
+    p_winner_id, p_loser_id, v_winner_elo, v_loser_elo,
+    v_change, p_recorded_by, p_challenge_id, 'pending'
+  )
+  returning id into v_match_id;
+
+  return v_match_id;
+end;
+$$ language plpgsql security definer;
+
+-- ============================================
+-- REPLACE CONFIRM_MATCH RPC (recalculates at confirm time)
+-- ============================================
+-- Recalculates Elo with current ratings and ranks for fairness.
+
+create or replace function public.confirm_match(
+  p_match_id uuid,
+  p_confirmer_id uuid
+) returns uuid as $$
+declare
+  v_match record;
+  v_winner_elo integer;
+  v_loser_elo integer;
+  v_winner_rank integer;
+  v_loser_rank integer;
+  v_total integer;
+  v_rank_diff integer;
+  v_raw_factor float;
+  v_multiplier float;
+  v_adjusted_k float;
+  v_expected float;
+  v_change integer;
+begin
+  -- Get and lock the match
+  select * into v_match
+  from public.matches
+  where id = p_match_id
+  for update;
+
+  -- Validate match exists
+  if v_match is null then
+    raise exception 'Match not found';
+  end if;
+
+  -- Validate match is pending
+  if v_match.status != 'pending' then
+    raise exception 'Match is not pending confirmation';
+  end if;
+
+  -- Validate confirmer is one of the players (but not the recorder)
+  if p_confirmer_id != v_match.winner_id and p_confirmer_id != v_match.loser_id then
+    raise exception 'Only match participants can confirm';
+  end if;
+
+  if p_confirmer_id = v_match.recorded_by then
+    raise exception 'The person who recorded the match cannot confirm it';
+  end if;
+
+  -- Lock player rows and get CURRENT ratings
+  select elo_rating into v_winner_elo from public.profiles where id = v_match.winner_id for update;
+  select elo_rating into v_loser_elo from public.profiles where id = v_match.loser_id for update;
+
+  -- Recalculate with current ranks
+  select r.rank, r.total_players into v_winner_rank, v_total
+    from public.get_player_rank(v_match.winner_id) r;
+  select r.rank into v_loser_rank
+    from public.get_player_rank(v_match.loser_id) r;
+
+  v_rank_diff := v_winner_rank - v_loser_rank;
+  v_raw_factor := 1.0 + (v_rank_diff::float / greatest(v_total, 1)::float) * 0.5;
+  v_multiplier := least(1.5, greatest(0.5, v_raw_factor));
+  v_adjusted_k := 32.0 * v_multiplier;
+
+  v_expected := 1.0 / (1.0 + power(10.0, (v_loser_elo - v_winner_elo)::float / 400.0));
+  v_change := greatest(1, round(v_adjusted_k * (1.0 - v_expected)));
+
+  -- Update match record with recalculated values
+  update public.matches
+  set status = 'confirmed',
+      confirmed_at = now(),
+      winner_elo_before = v_winner_elo,
+      loser_elo_before = v_loser_elo,
+      elo_change = v_change
+  where id = p_match_id;
+
+  -- Apply Elo changes
+  update public.profiles
+  set elo_rating = elo_rating + v_change, wins = wins + 1, updated_at = now()
+  where id = v_match.winner_id;
+
+  update public.profiles
+  set elo_rating = greatest(100, elo_rating - v_change), losses = losses + 1, updated_at = now()
+  where id = v_match.loser_id;
+
+  -- Complete challenge if applicable
+  if v_match.challenge_id is not null then
+    update public.challenges
+    set status = 'completed', completed_at = now()
+    where id = v_match.challenge_id;
+  end if;
+
+  return p_match_id;
+end;
+$$ language plpgsql security definer;


### PR DESCRIPTION
## Summary

- Elo changes now depend on **leaderboard position**, not just rating difference
- Upsets (lower-ranked beating higher-ranked) are rewarded more, expected wins are rewarded less
- Uses a rank-based K-factor multiplier (0.5x to 1.5x) on top of standard Elo expected score
- `confirm_match()` recalculates Elo at confirmation time using current ranks for fairness
- UI previews show rank context ("Rank #X vs #Y") and pending matches show approximate (`~`) Elo

### Example (10 players, both at 1200 Elo)

| Scenario | K Multiplier | Elo Change |
|---|---|---|
| #1 beats #10 (expected) | 0.55x | ~9 |
| #10 beats #1 (upset) | 1.45x | ~23 |
| #5 beats #6 (close) | 0.95x | ~15 |

### Files changed
- `lib/elo.ts` — New `calculateRankMultiplier()`, updated functions with optional `rankInfo` param
- `supabase/migrations/003_rank_weighted_elo.sql` — New migration replacing `record_match`, `create_pending_match`, `confirm_match` RPCs
- `components/matches/record-match-form.tsx` — Rank-aware Elo preview
- `components/matches/record-match-modal.tsx` — Rank-aware Elo preview
- `components/matches/pending-match-card.tsx` — Approximate indicator for pending matches

## Test plan

- [ ] Run migration `003_rank_weighted_elo.sql` in Supabase SQL editor
- [ ] Record match between #1 and last-place player — verify lower Elo change than before
- [ ] Record match where lower-ranked beats higher-ranked — verify higher Elo change
- [ ] Verify pending match flow: preview shows `~` estimate, confirmation recalculates with current ranks
- [ ] Verify tournament matches apply rank-weighted Elo immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)