### PR TITLE
Feat/experience elo

### DIFF
--- a/components/matches/awaiting-confirmation-card.tsx
+++ b/components/matches/awaiting-confirmation-card.tsx
@@ -27,7 +27,7 @@ export function AwaitingConfirmationCard({
 }) {
   const isWinner = currentUserId === match.winner_id;
   const opponent = isWinner ? loser : winner;
-  const eloChange = match.elo_change;
+  const eloChange = isWinner ? match.elo_change : (match.loser_elo_change ?? match.elo_change);
 
   return (
     <div className="flex items-center justify-between gap-3 rounded-lg border border-yellow-500/20 bg-yellow-500/5 px-3 py-2.5">

--- a/components/matches/match-card.tsx
+++ b/components/matches/match-card.tsx
@@ -28,21 +28,19 @@ function playerName(p: Profile) {
 
 function TeamDisplay({
   players,
-  change,
+  changes,
   isWinner,
-  layout,
 }: {
   players: Profile[];
-  change: number;
+  changes: number[];
   isWinner: boolean;
-  layout?: "list" | "grid";
 }) {
   const colorClass = isWinner ? "text-green-400" : "text-red-400";
   const sign = isWinner ? "+" : "-";
 
   return (
     <div className="relative z-20 flex flex-col items-center gap-1">
-      {players.map((p) => (
+      {players.map((p, i) => (
         <Link
           key={p.id}
           href={`/player/${p.id}`}
@@ -51,11 +49,11 @@ function TeamDisplay({
           <p className="text-base font-medium truncate">
             {playerName(p)}
           </p>
+          <p className={`text-xs ${colorClass} tabular-nums`}>
+            {sign}{Math.abs(changes[i])}
+          </p>
         </Link>
       ))}
-      <p className={`text-xs ${colorClass} tabular-nums`}>
-        {sign}{change} each
-      </p>
     </div>
   );
 }
@@ -87,14 +85,19 @@ export function MatchCard({
       .map((mp) => profiles.get(mp.player_id))
       .filter(Boolean) as Profile[];
 
-    const playerChange = matchPlayers.find((mp) => mp.team === "winner")?.elo_change ?? match.elo_change;
+    const winnerChanges = matchPlayers
+      .filter((mp) => mp.team === "winner")
+      .map((mp) => mp.elo_change);
+    const loserChanges = matchPlayers
+      .filter((mp) => mp.team === "loser")
+      .map((mp) => mp.elo_change);
 
     return (
       <div className={`relative flex items-center justify-around gap-4 rounded-xl border border-border p-4 overflow-hidden ${zenDots.className}`}>
         <div className="absolute inset-0 bg-zinc-900/80" />
         <div className="absolute inset-0 bg-orange-500/40 origin-top-left -skew-x-12" style={{ clipPath: "polygon(0 0, 60% 0, 40% 100%, 0 100%)" }} />
 
-        <TeamDisplay players={winnerPlayers} change={playerChange} isWinner layout={layout} />
+        <TeamDisplay players={winnerPlayers} changes={winnerChanges} isWinner />
 
         <div className="relative z-20 flex flex-col items-center gap-1">
           <Badge variant="outline" className="bg-purple-500/20 text-purple-400 border-purple-500/30 mb-1">
@@ -108,7 +111,7 @@ export function MatchCard({
           </span>
         </div>
 
-        <TeamDisplay players={loserPlayers} change={playerChange} isWinner={false} layout={layout} />
+        <TeamDisplay players={loserPlayers} changes={loserChanges} isWinner={false} />
       </div>
     );
   }
@@ -167,7 +170,7 @@ export function MatchCard({
             {playerName(loser)}
           </p>
           <p className="text-xs text-red-400 tabular-nums">
-            -{match.elo_change}
+            -{match.loser_elo_change ?? match.elo_change}
           </p>
         </div>
       </Link>

--- a/components/matches/pending-match-card.tsx
+++ b/components/matches/pending-match-card.tsx
@@ -61,7 +61,9 @@ export function PendingMatchCard({
     const isOnWinnerTeam = matchPlayers.some(
       (mp) => mp.player_id === currentUserId && mp.team === "winner"
     );
-    const playerChange = matchPlayers.find((mp) => mp.team === "winner")?.elo_change ?? match.elo_change;
+    const myChange = matchPlayers.find(
+      (mp) => mp.player_id === currentUserId
+    )?.elo_change ?? match.elo_change;
 
     return (
       <div className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 sm:flex-row sm:items-center">
@@ -92,7 +94,7 @@ export function PendingMatchCard({
                 isOnWinnerTeam ? "text-green-400" : "text-red-400"
               }`}
             >
-              ~{isOnWinnerTeam ? "+" : "-"}{playerChange} each
+              ~{isOnWinnerTeam ? "+" : "-"}{Math.abs(myChange)}
             </span>
           </div>
           <p className="text-xs text-muted-foreground mt-1">
@@ -112,7 +114,7 @@ export function PendingMatchCard({
   // Singles (existing layout)
   const isWinner = currentUserId === match.winner_id;
   const opponent = isWinner ? loser : winner;
-  const eloChange = match.elo_change;
+  const eloChange = isWinner ? match.elo_change : (match.loser_elo_change ?? match.elo_change);
   const currentElo = isWinner ? match.winner_elo_before : match.loser_elo_before;
   const newElo = isWinner
     ? currentElo + eloChange

--- a/components/matches/record-match-form.tsx
+++ b/components/matches/record-match-form.tsx
@@ -72,6 +72,9 @@ export function RecordMatchForm({
           winnerRank,
           loserRank,
           totalPlayers,
+        }, {
+          winnerTotalMatches: singlesWinner.total_wins + singlesWinner.total_losses,
+          loserTotalMatches: singlesLoser.total_wins + singlesLoser.total_losses,
         })
       : null;
 
@@ -97,7 +100,13 @@ export function RecordMatchForm({
           doublesWinner1.elo_rating,
           doublesWinner2.elo_rating,
           doublesLoser1.elo_rating,
-          doublesLoser2.elo_rating
+          doublesLoser2.elo_rating,
+          {
+            winner1TotalMatches: doublesWinner1.total_wins + doublesWinner1.total_losses,
+            winner2TotalMatches: doublesWinner2.total_wins + doublesWinner2.total_losses,
+            loser1TotalMatches: doublesLoser1.total_wins + doublesLoser1.total_losses,
+            loser2TotalMatches: doublesLoser2.total_wins + doublesLoser2.total_losses,
+          }
         )
       : null;
 
@@ -253,14 +262,14 @@ export function RecordMatchForm({
           <div className="flex justify-between text-sm">
             <span>{singlesWinner.display_name || singlesWinner.username}</span>
             <span className="text-green-400 tabular-nums font-medium">
-              {singlesWinner.elo_rating} → {singlesWinner.elo_rating + singlesPreview} (+{singlesPreview})
+              {singlesWinner.elo_rating} → {singlesWinner.elo_rating + singlesPreview.winnerGain} (+{singlesPreview.winnerGain})
             </span>
           </div>
           <div className="flex justify-between text-sm">
             <span>{singlesLoser.display_name || singlesLoser.username}</span>
             <span className="text-red-400 tabular-nums font-medium">
-              {singlesLoser.elo_rating} → {Math.max(MINIMUM_RATING, singlesLoser.elo_rating - singlesPreview)} (-
-              {singlesPreview})
+              {singlesLoser.elo_rating} → {Math.max(MINIMUM_RATING, singlesLoser.elo_rating - singlesPreview.loserLoss)} (-
+              {singlesPreview.loserLoss})
             </span>
           </div>
         </div>
@@ -277,20 +286,26 @@ export function RecordMatchForm({
               {doublesLoser1.elo_rating + doublesLoser2.elo_rating}
             </p>
           </div>
-          {[doublesWinner1, doublesWinner2].map((p) => (
+          {([
+            { player: doublesWinner1, change: doublesPreview.winner1Change },
+            { player: doublesWinner2, change: doublesPreview.winner2Change },
+          ] as const).map(({ player: p, change }) => (
             <div key={p.id} className="flex justify-between text-sm">
               <span>{p.display_name || p.username}</span>
               <span className="text-green-400 tabular-nums font-medium">
-                {p.elo_rating} → {p.elo_rating + doublesPreview.playerChange} (+{doublesPreview.playerChange})
+                {p.elo_rating} → {p.elo_rating + change} (+{change})
               </span>
             </div>
           ))}
-          {[doublesLoser1, doublesLoser2].map((p) => (
+          {([
+            { player: doublesLoser1, change: doublesPreview.loser1Change },
+            { player: doublesLoser2, change: doublesPreview.loser2Change },
+          ] as const).map(({ player: p, change }) => (
             <div key={p.id} className="flex justify-between text-sm">
               <span>{p.display_name || p.username}</span>
               <span className="text-red-400 tabular-nums font-medium">
-                {p.elo_rating} → {Math.max(MINIMUM_RATING, p.elo_rating - doublesPreview.playerChange)} (-
-                {doublesPreview.playerChange})
+                {p.elo_rating} → {Math.max(MINIMUM_RATING, p.elo_rating - change)} (-
+                {change})
               </span>
             </div>
           ))}

--- a/components/matches/record-match-modal.tsx
+++ b/components/matches/record-match-modal.tsx
@@ -31,13 +31,15 @@ import type { MatchType, Profile } from "@/lib/types/database";
 function EloPreview({
   winner,
   loser,
-  change,
+  winnerGain,
+  loserLoss,
   winnerRank,
   loserRank,
 }: {
   winner: Profile;
   loser: Profile;
-  change: number;
+  winnerGain: number;
+  loserLoss: number;
   winnerRank: number;
   loserRank: number;
 }) {
@@ -52,14 +54,14 @@ function EloPreview({
       <div className="flex justify-between text-sm">
         <span>{winner.display_name || winner.username}</span>
         <span className="text-green-400 tabular-nums font-medium">
-          {winner.elo_rating} → {winner.elo_rating + change} (+{change})
+          {winner.elo_rating} → {winner.elo_rating + winnerGain} (+{winnerGain})
         </span>
       </div>
       <div className="flex justify-between text-sm">
         <span>{loser.display_name || loser.username}</span>
         <span className="text-red-400 tabular-nums font-medium">
-          {loser.elo_rating} → {Math.max(MINIMUM_RATING, loser.elo_rating - change)} (-
-          {change})
+          {loser.elo_rating} → {Math.max(MINIMUM_RATING, loser.elo_rating - loserLoss)} (-
+          {loserLoss})
         </span>
       </div>
     </div>
@@ -69,13 +71,15 @@ function EloPreview({
 function DoublesEloPreview({
   winners,
   losers,
-  playerChange,
+  winnerChanges,
+  loserChanges,
   teamWinnerElo,
   teamLoserElo,
 }: {
   winners: Profile[];
   losers: Profile[];
-  playerChange: number;
+  winnerChanges: number[];
+  loserChanges: number[];
   teamWinnerElo: number;
   teamLoserElo: number;
 }) {
@@ -87,20 +91,20 @@ function DoublesEloPreview({
           Team {teamWinnerElo} vs {teamLoserElo}
         </p>
       </div>
-      {winners.map((p) => (
+      {winners.map((p, i) => (
         <div key={p.id} className="flex justify-between text-sm">
           <span>{p.display_name || p.username}</span>
           <span className="text-green-400 tabular-nums font-medium">
-            {p.elo_rating} → {p.elo_rating + playerChange} (+{playerChange})
+            {p.elo_rating} → {p.elo_rating + winnerChanges[i]} (+{winnerChanges[i]})
           </span>
         </div>
       ))}
-      {losers.map((p) => (
+      {losers.map((p, i) => (
         <div key={p.id} className="flex justify-between text-sm">
           <span>{p.display_name || p.username}</span>
           <span className="text-red-400 tabular-nums font-medium">
-            {p.elo_rating} → {Math.max(MINIMUM_RATING, p.elo_rating - playerChange)} (-
-            {playerChange})
+            {p.elo_rating} → {Math.max(MINIMUM_RATING, p.elo_rating - loserChanges[i])} (-
+            {loserChanges[i]})
           </span>
         </div>
       ))}
@@ -171,6 +175,9 @@ function RecordMatchContent({
           winnerRank,
           loserRank,
           totalPlayers,
+        }, {
+          winnerTotalMatches: singlesWinner.total_wins + singlesWinner.total_losses,
+          loserTotalMatches: singlesLoser.total_wins + singlesLoser.total_losses,
         })
       : null;
 
@@ -196,7 +203,13 @@ function RecordMatchContent({
           doublesWinner1.elo_rating,
           doublesWinner2.elo_rating,
           doublesLoser1.elo_rating,
-          doublesLoser2.elo_rating
+          doublesLoser2.elo_rating,
+          {
+            winner1TotalMatches: doublesWinner1.total_wins + doublesWinner1.total_losses,
+            winner2TotalMatches: doublesWinner2.total_wins + doublesWinner2.total_losses,
+            loser1TotalMatches: doublesLoser1.total_wins + doublesLoser1.total_losses,
+            loser2TotalMatches: doublesLoser2.total_wins + doublesLoser2.total_losses,
+          }
         )
       : null;
 
@@ -336,7 +349,8 @@ function RecordMatchContent({
         <EloPreview
           winner={singlesWinner}
           loser={singlesLoser}
-          change={singlesPreview}
+          winnerGain={singlesPreview.winnerGain}
+          loserLoss={singlesPreview.loserLoss}
           winnerRank={winnerRank}
           loserRank={loserRank}
         />
@@ -346,7 +360,8 @@ function RecordMatchContent({
         <DoublesEloPreview
           winners={[doublesWinner1, doublesWinner2]}
           losers={[doublesLoser1, doublesLoser2]}
-          playerChange={doublesPreview.playerChange}
+          winnerChanges={[doublesPreview.winner1Change, doublesPreview.winner2Change]}
+          loserChanges={[doublesPreview.loser1Change, doublesPreview.loser2Change]}
           teamWinnerElo={doublesWinner1.elo_rating + doublesWinner2.elo_rating}
           teamLoserElo={doublesLoser1.elo_rating + doublesLoser2.elo_rating}
         />

--- a/components/profile/elo-chart.tsx
+++ b/components/profile/elo-chart.tsx
@@ -25,7 +25,7 @@ export function EloChart({
     const won = match.winner_id === playerId;
     const elo = won
       ? match.winner_elo_before + match.elo_change
-      : Math.max(100, match.loser_elo_before - match.elo_change);
+      : Math.max(100, match.loser_elo_before - (match.loser_elo_change ?? match.elo_change));
     const date = new Date(match.played_at);
     points.push({
       elo,

--- a/components/profile/stats-grid.tsx
+++ b/components/profile/stats-grid.tsx
@@ -53,7 +53,7 @@ export function StatsGrid({
     if (match.winner_id === profile.id) {
       currentElo = match.winner_elo_before + match.elo_change;
     } else {
-      currentElo = Math.max(100, match.loser_elo_before - match.elo_change);
+      currentElo = Math.max(100, match.loser_elo_before - (match.loser_elo_change ?? match.elo_change));
     }
     bestElo = Math.max(bestElo, currentElo);
   }

--- a/lib/elo.ts
+++ b/lib/elo.ts
@@ -7,10 +7,27 @@ export const RANK_SCALE = 0.5;
 export const K_MIN_MULTIPLIER = 0.5;
 export const K_MAX_MULTIPLIER = 1.5;
 
+// Experience-based K-factor constants
+export const K_EXP_MIN = 0.6;
+export const K_EXP_MAX = 1.4;
+export const K_EXP_SCALE = 30;
+
 export type RankInfo = {
   winnerRank: number;
   loserRank: number;
   totalPlayers: number;
+};
+
+export type ExperienceInfo = {
+  winnerTotalMatches: number;
+  loserTotalMatches: number;
+};
+
+export type DoublesExperienceInfo = {
+  winner1TotalMatches: number;
+  winner2TotalMatches: number;
+  loser1TotalMatches: number;
+  loser2TotalMatches: number;
 };
 
 /**
@@ -22,10 +39,6 @@ export function expectedScore(ratingA: number, ratingB: number): number {
 
 /**
  * Calculate the K-factor multiplier based on rank positions.
- *
- * When the higher-ranked player wins (expected), multiplier < 1 (less Elo exchanged).
- * When the lower-ranked player wins (upset), multiplier > 1 (more Elo exchanged).
- * When adjacent ranks play, multiplier ~ 1 (normal Elo exchange).
  */
 export function calculateRankMultiplier(
   winnerRank: number,
@@ -39,15 +52,25 @@ export function calculateRankMultiplier(
 }
 
 /**
+ * Calculate experience multiplier based on total all-time matches.
+ * More games → higher multiplier (veteran, max stake).
+ * Fewer games → lower multiplier (newbie, protected).
+ */
+export function calculateExpMultiplier(totalMatches: number): number {
+  return Math.min(K_EXP_MAX, K_EXP_MIN + totalMatches / K_EXP_SCALE);
+}
+
+/**
  * Calculate Elo change after a match.
- * Returns a positive integer — winner gains this, loser loses it.
- * If rankInfo is provided, K-factor is scaled by rank proximity.
+ * Returns asymmetric changes — winner gain and loser loss may differ
+ * when experience info is provided.
  */
 export function calculateEloChange(
   winnerRating: number,
   loserRating: number,
-  rankInfo?: RankInfo
-): number {
+  rankInfo?: RankInfo,
+  experienceInfo?: ExperienceInfo
+): { winnerGain: number; loserLoss: number } {
   const expected = expectedScore(winnerRating, loserRating);
   const multiplier = rankInfo
     ? calculateRankMultiplier(
@@ -57,26 +80,65 @@ export function calculateEloChange(
       )
     : 1;
   const adjustedK = K_FACTOR * multiplier;
-  return Math.max(1, Math.round(adjustedK * (1 - expected)));
+  const baseChange = Math.max(1, Math.round(adjustedK * (1 - expected)));
+
+  if (experienceInfo) {
+    const winnerExp = calculateExpMultiplier(experienceInfo.winnerTotalMatches);
+    const loserExp = calculateExpMultiplier(experienceInfo.loserTotalMatches);
+    return {
+      winnerGain: Math.max(1, Math.round(baseChange * winnerExp)),
+      loserLoss: Math.max(1, Math.round(baseChange * loserExp)),
+    };
+  }
+
+  return { winnerGain: baseChange, loserLoss: baseChange };
 }
 
 /**
  * Calculate Elo change for a doubles match.
  * Team Elo = sum of individual Elos. Flat K=32 (no rank-weighting).
- * Returns team-level change and per-player change (half, rounded).
+ * Returns per-player changes (experience-scaled when info provided).
  */
 export function calculateDoublesEloChange(
   winner1Rating: number,
   winner2Rating: number,
   loser1Rating: number,
-  loser2Rating: number
-): { teamChange: number; playerChange: number } {
+  loser2Rating: number,
+  experienceInfo?: DoublesExperienceInfo
+): {
+  teamChange: number;
+  winner1Change: number;
+  winner2Change: number;
+  loser1Change: number;
+  loser2Change: number;
+} {
   const teamWinnerElo = winner1Rating + winner2Rating;
   const teamLoserElo = loser1Rating + loser2Rating;
   const expected = expectedScore(teamWinnerElo, teamLoserElo);
   const teamChange = Math.max(1, Math.round(K_FACTOR * (1 - expected)));
   const playerChange = Math.max(1, Math.round(teamChange / 2));
-  return { teamChange, playerChange };
+
+  if (experienceInfo) {
+    const w1Exp = calculateExpMultiplier(experienceInfo.winner1TotalMatches);
+    const w2Exp = calculateExpMultiplier(experienceInfo.winner2TotalMatches);
+    const l1Exp = calculateExpMultiplier(experienceInfo.loser1TotalMatches);
+    const l2Exp = calculateExpMultiplier(experienceInfo.loser2TotalMatches);
+    return {
+      teamChange,
+      winner1Change: Math.max(1, Math.round(playerChange * w1Exp)),
+      winner2Change: Math.max(1, Math.round(playerChange * w2Exp)),
+      loser1Change: Math.max(1, Math.round(playerChange * l1Exp)),
+      loser2Change: Math.max(1, Math.round(playerChange * l2Exp)),
+    };
+  }
+
+  return {
+    teamChange,
+    winner1Change: playerChange,
+    winner2Change: playerChange,
+    loser1Change: playerChange,
+    loser2Change: playerChange,
+  };
 }
 
 /**
@@ -85,16 +147,24 @@ export function calculateDoublesEloChange(
 export function applyMatchResult(
   winnerRating: number,
   loserRating: number,
-  rankInfo?: RankInfo
+  rankInfo?: RankInfo,
+  experienceInfo?: ExperienceInfo
 ): {
   newWinnerRating: number;
   newLoserRating: number;
-  eloChange: number;
+  winnerGain: number;
+  loserLoss: number;
 } {
-  const eloChange = calculateEloChange(winnerRating, loserRating, rankInfo);
+  const { winnerGain, loserLoss } = calculateEloChange(
+    winnerRating,
+    loserRating,
+    rankInfo,
+    experienceInfo
+  );
   return {
-    newWinnerRating: winnerRating + eloChange,
-    newLoserRating: Math.max(MINIMUM_RATING, loserRating - eloChange),
-    eloChange,
+    newWinnerRating: winnerRating + winnerGain,
+    newLoserRating: Math.max(MINIMUM_RATING, loserRating - loserLoss),
+    winnerGain,
+    loserLoss,
   };
 }

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -23,6 +23,7 @@ export interface Match {
   winner_elo_before: number;
   loser_elo_before: number;
   elo_change: number;
+  loser_elo_change: number | null;
   challenge_id: string | null;
   tournament_match_id: string | null;
   season_id: string | null;

--- a/supabase/migrations/011_experience_elo.sql
+++ b/supabase/migrations/011_experience_elo.sql
@@ -1,0 +1,667 @@
+-- ATP Rank: Experience-Based K-Factor for Elo System
+-- Scales Elo changes per-player based on total match count (all-time).
+-- More games = higher multiplier (veteran, max stake).
+-- Fewer games = lower multiplier (newbie, protected).
+-- Asymmetric: winner and loser each get their own multiplier.
+--
+-- Formula: exp_multiplier(total_matches) = min(1.4, 0.6 + total_matches / 30)
+--
+-- Run this migration in your Supabase SQL editor (DO NOT run via CLI).
+
+-- ============================================
+-- ADD LOSER_ELO_CHANGE COLUMN
+-- ============================================
+-- Winner's gain stored in elo_change (existing), loser's loss in loser_elo_change.
+-- NULL for old rows → app falls back to loser_elo_change ?? elo_change.
+alter table public.matches add column loser_elo_change integer;
+
+-- ============================================
+-- HELPER: EXPERIENCE MULTIPLIER
+-- ============================================
+create or replace function public.calc_exp_multiplier(p_total_matches integer)
+returns float as $$
+begin
+  return least(1.4, 0.6 + p_total_matches::float / 30.0);
+end;
+$$ language plpgsql immutable;
+
+-- ============================================
+-- REPLACE RECORD_MATCH RPC (experience-weighted)
+-- ============================================
+create or replace function public.record_match(
+  p_winner_id uuid,
+  p_loser_id uuid,
+  p_recorded_by uuid,
+  p_challenge_id uuid default null,
+  p_tournament_match_id uuid default null
+) returns uuid as $$
+declare
+  v_winner_elo integer;
+  v_loser_elo integer;
+  v_winner_rank integer;
+  v_loser_rank integer;
+  v_total integer;
+  v_rank_diff integer;
+  v_raw_factor float;
+  v_multiplier float;
+  v_adjusted_k float;
+  v_expected float;
+  v_base_change integer;
+  v_winner_total integer;
+  v_loser_total integer;
+  v_winner_exp float;
+  v_loser_exp float;
+  v_winner_change integer;
+  v_loser_change integer;
+  v_match_id uuid;
+  v_season_id uuid;
+begin
+  v_season_id := public.get_active_season_id();
+
+  -- Lock and get current ratings + total matches
+  select elo_rating, total_wins + total_losses
+    into v_winner_elo, v_winner_total
+    from public.profiles where id = p_winner_id for update;
+  select elo_rating, total_wins + total_losses
+    into v_loser_elo, v_loser_total
+    from public.profiles where id = p_loser_id for update;
+
+  -- Get ranks
+  select r.rank, r.total_players into v_winner_rank, v_total
+    from public.get_player_rank(p_winner_id) r;
+  select r.rank into v_loser_rank
+    from public.get_player_rank(p_loser_id) r;
+
+  -- Rank-weighted K-factor
+  v_rank_diff := v_winner_rank - v_loser_rank;
+  v_raw_factor := 1.0 + (v_rank_diff::float / greatest(v_total, 1)::float) * 0.5;
+  v_multiplier := least(1.5, greatest(0.5, v_raw_factor));
+  v_adjusted_k := 32.0 * v_multiplier;
+
+  -- Base Elo change (before experience scaling)
+  v_expected := 1.0 / (1.0 + power(10.0, (v_loser_elo - v_winner_elo)::float / 400.0));
+  v_base_change := greatest(1, round(v_adjusted_k * (1.0 - v_expected)));
+
+  -- Experience multipliers (asymmetric)
+  v_winner_exp := public.calc_exp_multiplier(v_winner_total);
+  v_loser_exp := public.calc_exp_multiplier(v_loser_total);
+  v_winner_change := greatest(1, round(v_base_change * v_winner_exp));
+  v_loser_change := greatest(1, round(v_base_change * v_loser_exp));
+
+  -- Insert match record
+  insert into public.matches (
+    winner_id, loser_id, winner_elo_before, loser_elo_before,
+    elo_change, loser_elo_change, recorded_by, challenge_id,
+    tournament_match_id, season_id, match_type, status
+  )
+  values (
+    p_winner_id, p_loser_id, v_winner_elo, v_loser_elo,
+    v_winner_change, v_loser_change, p_recorded_by, p_challenge_id,
+    p_tournament_match_id, v_season_id, 'singles', 'confirmed'
+  )
+  returning id into v_match_id;
+
+  -- Update winner (season + total)
+  update public.profiles
+  set elo_rating = elo_rating + v_winner_change,
+      wins = wins + 1,
+      total_wins = total_wins + 1,
+      updated_at = now()
+  where id = p_winner_id;
+
+  -- Update loser (floor at 100, season + total)
+  update public.profiles
+  set elo_rating = greatest(100, elo_rating - v_loser_change),
+      losses = losses + 1,
+      total_losses = total_losses + 1,
+      updated_at = now()
+  where id = p_loser_id;
+
+  -- Complete challenge if applicable
+  if p_challenge_id is not null then
+    update public.challenges
+    set status = 'completed', completed_at = now()
+    where id = p_challenge_id;
+  end if;
+
+  -- Update tournament match if applicable
+  if p_tournament_match_id is not null then
+    update public.tournament_matches
+    set winner_id = p_winner_id, match_id = v_match_id
+    where id = p_tournament_match_id;
+  end if;
+
+  return v_match_id;
+end;
+$$ language plpgsql security definer;
+
+-- ============================================
+-- REPLACE CREATE_PENDING_MATCH RPC (experience-weighted)
+-- ============================================
+create or replace function public.create_pending_match(
+  p_winner_id uuid,
+  p_loser_id uuid,
+  p_recorded_by uuid,
+  p_challenge_id uuid default null
+) returns uuid as $$
+declare
+  v_winner_elo integer;
+  v_loser_elo integer;
+  v_winner_rank integer;
+  v_loser_rank integer;
+  v_total integer;
+  v_rank_diff integer;
+  v_raw_factor float;
+  v_multiplier float;
+  v_adjusted_k float;
+  v_expected float;
+  v_base_change integer;
+  v_winner_total integer;
+  v_loser_total integer;
+  v_winner_exp float;
+  v_loser_exp float;
+  v_winner_change integer;
+  v_loser_change integer;
+  v_match_id uuid;
+  v_season_id uuid;
+begin
+  v_season_id := public.get_active_season_id();
+
+  -- Get current ratings + total matches (no lock, preview only)
+  select elo_rating, total_wins + total_losses
+    into v_winner_elo, v_winner_total
+    from public.profiles where id = p_winner_id;
+  select elo_rating, total_wins + total_losses
+    into v_loser_elo, v_loser_total
+    from public.profiles where id = p_loser_id;
+
+  -- Get ranks
+  select r.rank, r.total_players into v_winner_rank, v_total
+    from public.get_player_rank(p_winner_id) r;
+  select r.rank into v_loser_rank
+    from public.get_player_rank(p_loser_id) r;
+
+  -- Rank-weighted K-factor
+  v_rank_diff := v_winner_rank - v_loser_rank;
+  v_raw_factor := 1.0 + (v_rank_diff::float / greatest(v_total, 1)::float) * 0.5;
+  v_multiplier := least(1.5, greatest(0.5, v_raw_factor));
+  v_adjusted_k := 32.0 * v_multiplier;
+
+  -- Base Elo change
+  v_expected := 1.0 / (1.0 + power(10.0, (v_loser_elo - v_winner_elo)::float / 400.0));
+  v_base_change := greatest(1, round(v_adjusted_k * (1.0 - v_expected)));
+
+  -- Experience multipliers (asymmetric)
+  v_winner_exp := public.calc_exp_multiplier(v_winner_total);
+  v_loser_exp := public.calc_exp_multiplier(v_loser_total);
+  v_winner_change := greatest(1, round(v_base_change * v_winner_exp));
+  v_loser_change := greatest(1, round(v_base_change * v_loser_exp));
+
+  -- Insert match record with pending status
+  insert into public.matches (
+    winner_id, loser_id, winner_elo_before, loser_elo_before,
+    elo_change, loser_elo_change, recorded_by, challenge_id,
+    status, season_id, match_type
+  )
+  values (
+    p_winner_id, p_loser_id, v_winner_elo, v_loser_elo,
+    v_winner_change, v_loser_change, p_recorded_by, p_challenge_id,
+    'pending', v_season_id, 'singles'
+  )
+  returning id into v_match_id;
+
+  return v_match_id;
+end;
+$$ language plpgsql security definer;
+
+-- ============================================
+-- REPLACE CONFIRM_MATCH RPC (experience-weighted)
+-- ============================================
+create or replace function public.confirm_match(
+  p_match_id uuid,
+  p_confirmer_id uuid
+) returns uuid as $$
+declare
+  v_match record;
+  -- singles vars
+  v_winner_elo integer;
+  v_loser_elo integer;
+  v_winner_rank integer;
+  v_loser_rank integer;
+  v_total integer;
+  v_rank_diff integer;
+  v_raw_factor float;
+  v_multiplier float;
+  v_adjusted_k float;
+  v_expected float;
+  v_base_change integer;
+  v_winner_total integer;
+  v_loser_total integer;
+  v_winner_exp float;
+  v_loser_exp float;
+  v_winner_change integer;
+  v_loser_change integer;
+  -- doubles vars
+  v_team_winner_elo integer;
+  v_team_loser_elo integer;
+  v_team_change integer;
+  v_is_participant boolean;
+  v_w1_id uuid;
+  v_w2_id uuid;
+  v_l1_id uuid;
+  v_l2_id uuid;
+  v_w1_elo integer;
+  v_w2_elo integer;
+  v_l1_elo integer;
+  v_l2_elo integer;
+  v_w1_total integer;
+  v_w2_total integer;
+  v_l1_total integer;
+  v_l2_total integer;
+  v_w1_exp float;
+  v_w2_exp float;
+  v_l1_exp float;
+  v_l2_exp float;
+  v_w1_change integer;
+  v_w2_change integer;
+  v_l1_change integer;
+  v_l2_change integer;
+  v_player_change integer;
+begin
+  -- Get and lock the match
+  select * into v_match
+  from public.matches
+  where id = p_match_id
+  for update;
+
+  if v_match is null then
+    raise exception 'Match not found';
+  end if;
+
+  if v_match.status != 'pending' then
+    raise exception 'Match is not pending confirmation';
+  end if;
+
+  if v_match.match_type = 'doubles' then
+    -- ========== DOUBLES CONFIRMATION ==========
+
+    select exists(
+      select 1 from public.match_players
+      where match_id = p_match_id and player_id = p_confirmer_id
+    ) into v_is_participant;
+
+    if not v_is_participant then
+      raise exception 'Only match participants can confirm';
+    end if;
+
+    if p_confirmer_id = v_match.recorded_by then
+      raise exception 'The person who recorded the match cannot confirm it';
+    end if;
+
+    -- Get player IDs from match_players
+    select player_id into v_w1_id from public.match_players
+      where match_id = p_match_id and team = 'winner' order by player_id limit 1;
+    select player_id into v_w2_id from public.match_players
+      where match_id = p_match_id and team = 'winner' order by player_id offset 1 limit 1;
+    select player_id into v_l1_id from public.match_players
+      where match_id = p_match_id and team = 'loser' order by player_id limit 1;
+    select player_id into v_l2_id from public.match_players
+      where match_id = p_match_id and team = 'loser' order by player_id offset 1 limit 1;
+
+    -- Lock and get current Elo + total matches for all 4 players
+    select elo_rating, total_wins + total_losses into v_w1_elo, v_w1_total
+      from public.profiles where id = v_w1_id for update;
+    select elo_rating, total_wins + total_losses into v_w2_elo, v_w2_total
+      from public.profiles where id = v_w2_id for update;
+    select elo_rating, total_wins + total_losses into v_l1_elo, v_l1_total
+      from public.profiles where id = v_l1_id for update;
+    select elo_rating, total_wins + total_losses into v_l2_elo, v_l2_total
+      from public.profiles where id = v_l2_id for update;
+
+    -- Recalculate with current team Elos
+    v_team_winner_elo := v_w1_elo + v_w2_elo;
+    v_team_loser_elo := v_l1_elo + v_l2_elo;
+
+    v_expected := 1.0 / (1.0 + power(10.0, (v_team_loser_elo - v_team_winner_elo)::float / 400.0));
+    v_team_change := greatest(1, round(32 * (1.0 - v_expected)));
+    v_player_change := greatest(1, round(v_team_change::float / 2.0));
+
+    -- Per-player experience multipliers
+    v_w1_exp := public.calc_exp_multiplier(v_w1_total);
+    v_w2_exp := public.calc_exp_multiplier(v_w2_total);
+    v_l1_exp := public.calc_exp_multiplier(v_l1_total);
+    v_l2_exp := public.calc_exp_multiplier(v_l2_total);
+    v_w1_change := greatest(1, round(v_player_change * v_w1_exp));
+    v_w2_change := greatest(1, round(v_player_change * v_w2_exp));
+    v_l1_change := greatest(1, round(v_player_change * v_l1_exp));
+    v_l2_change := greatest(1, round(v_player_change * v_l2_exp));
+
+    -- Update match record (elo_change = winner1's gain for backward compat)
+    update public.matches
+    set status = 'confirmed',
+        confirmed_at = now(),
+        winner_elo_before = v_w1_elo,
+        loser_elo_before = v_l1_elo,
+        elo_change = v_w1_change,
+        loser_elo_change = v_l1_change
+    where id = p_match_id;
+
+    -- Update match_players with per-player experience-scaled changes
+    update public.match_players
+    set elo_before = case player_id
+          when v_w1_id then v_w1_elo
+          when v_w2_id then v_w2_elo
+          when v_l1_id then v_l1_elo
+          when v_l2_id then v_l2_elo
+        end,
+        elo_change = case player_id
+          when v_w1_id then v_w1_change
+          when v_w2_id then v_w2_change
+          when v_l1_id then -v_l1_change
+          when v_l2_id then -v_l2_change
+        end
+    where match_id = p_match_id;
+
+    -- Apply Elo to each player individually (different changes)
+    update public.profiles
+    set elo_rating = elo_rating + v_w1_change, wins = wins + 1,
+        total_wins = total_wins + 1, updated_at = now()
+    where id = v_w1_id;
+
+    update public.profiles
+    set elo_rating = elo_rating + v_w2_change, wins = wins + 1,
+        total_wins = total_wins + 1, updated_at = now()
+    where id = v_w2_id;
+
+    update public.profiles
+    set elo_rating = greatest(100, elo_rating - v_l1_change), losses = losses + 1,
+        total_losses = total_losses + 1, updated_at = now()
+    where id = v_l1_id;
+
+    update public.profiles
+    set elo_rating = greatest(100, elo_rating - v_l2_change), losses = losses + 1,
+        total_losses = total_losses + 1, updated_at = now()
+    where id = v_l2_id;
+
+  else
+    -- ========== SINGLES CONFIRMATION ==========
+
+    if p_confirmer_id != v_match.winner_id and p_confirmer_id != v_match.loser_id then
+      raise exception 'Only match participants can confirm';
+    end if;
+
+    if p_confirmer_id = v_match.recorded_by then
+      raise exception 'The person who recorded the match cannot confirm it';
+    end if;
+
+    -- Lock player rows and get CURRENT ratings + total matches
+    select elo_rating, total_wins + total_losses
+      into v_winner_elo, v_winner_total
+      from public.profiles where id = v_match.winner_id for update;
+    select elo_rating, total_wins + total_losses
+      into v_loser_elo, v_loser_total
+      from public.profiles where id = v_match.loser_id for update;
+
+    -- Recalculate with current ranks
+    select r.rank, r.total_players into v_winner_rank, v_total
+      from public.get_player_rank(v_match.winner_id) r;
+    select r.rank into v_loser_rank
+      from public.get_player_rank(v_match.loser_id) r;
+
+    v_rank_diff := v_winner_rank - v_loser_rank;
+    v_raw_factor := 1.0 + (v_rank_diff::float / greatest(v_total, 1)::float) * 0.5;
+    v_multiplier := least(1.5, greatest(0.5, v_raw_factor));
+    v_adjusted_k := 32.0 * v_multiplier;
+
+    v_expected := 1.0 / (1.0 + power(10.0, (v_loser_elo - v_winner_elo)::float / 400.0));
+    v_base_change := greatest(1, round(v_adjusted_k * (1.0 - v_expected)));
+
+    -- Experience multipliers (asymmetric)
+    v_winner_exp := public.calc_exp_multiplier(v_winner_total);
+    v_loser_exp := public.calc_exp_multiplier(v_loser_total);
+    v_winner_change := greatest(1, round(v_base_change * v_winner_exp));
+    v_loser_change := greatest(1, round(v_base_change * v_loser_exp));
+
+    -- Update match record with recalculated values
+    update public.matches
+    set status = 'confirmed',
+        confirmed_at = now(),
+        winner_elo_before = v_winner_elo,
+        loser_elo_before = v_loser_elo,
+        elo_change = v_winner_change,
+        loser_elo_change = v_loser_change
+    where id = p_match_id;
+
+    -- Apply Elo changes (season + total)
+    update public.profiles
+    set elo_rating = elo_rating + v_winner_change,
+        wins = wins + 1,
+        total_wins = total_wins + 1,
+        updated_at = now()
+    where id = v_match.winner_id;
+
+    update public.profiles
+    set elo_rating = greatest(100, elo_rating - v_loser_change),
+        losses = losses + 1,
+        total_losses = total_losses + 1,
+        updated_at = now()
+    where id = v_match.loser_id;
+  end if;
+
+  -- Complete challenge if applicable
+  if v_match.challenge_id is not null then
+    update public.challenges
+    set status = 'completed', completed_at = now()
+    where id = v_match.challenge_id;
+  end if;
+
+  return p_match_id;
+end;
+$$ language plpgsql security definer;
+
+-- ============================================
+-- REPLACE RECORD_DOUBLES_MATCH RPC (experience-weighted)
+-- ============================================
+create or replace function public.record_doubles_match(
+  p_winner1_id uuid,
+  p_winner2_id uuid,
+  p_loser1_id uuid,
+  p_loser2_id uuid,
+  p_recorded_by uuid,
+  p_challenge_id uuid default null
+) returns uuid as $$
+declare
+  v_w1_elo integer;
+  v_w2_elo integer;
+  v_l1_elo integer;
+  v_l2_elo integer;
+  v_w1_total integer;
+  v_w2_total integer;
+  v_l1_total integer;
+  v_l2_total integer;
+  v_team_winner_elo integer;
+  v_team_loser_elo integer;
+  v_expected float;
+  v_team_change integer;
+  v_player_change integer;
+  v_w1_exp float;
+  v_w2_exp float;
+  v_l1_exp float;
+  v_l2_exp float;
+  v_w1_change integer;
+  v_w2_change integer;
+  v_l1_change integer;
+  v_l2_change integer;
+  v_match_id uuid;
+  v_season_id uuid;
+begin
+  v_season_id := public.get_active_season_id();
+
+  -- Lock and get current ratings + total matches for all 4 players
+  select elo_rating, total_wins + total_losses into v_w1_elo, v_w1_total
+    from public.profiles where id = p_winner1_id for update;
+  select elo_rating, total_wins + total_losses into v_w2_elo, v_w2_total
+    from public.profiles where id = p_winner2_id for update;
+  select elo_rating, total_wins + total_losses into v_l1_elo, v_l1_total
+    from public.profiles where id = p_loser1_id for update;
+  select elo_rating, total_wins + total_losses into v_l2_elo, v_l2_total
+    from public.profiles where id = p_loser2_id for update;
+
+  -- Team Elo
+  v_team_winner_elo := v_w1_elo + v_w2_elo;
+  v_team_loser_elo := v_l1_elo + v_l2_elo;
+
+  v_expected := 1.0 / (1.0 + power(10.0, (v_team_loser_elo - v_team_winner_elo)::float / 400.0));
+  v_team_change := greatest(1, round(32 * (1.0 - v_expected)));
+  v_player_change := greatest(1, round(v_team_change::float / 2.0));
+
+  -- Per-player experience multipliers
+  v_w1_exp := public.calc_exp_multiplier(v_w1_total);
+  v_w2_exp := public.calc_exp_multiplier(v_w2_total);
+  v_l1_exp := public.calc_exp_multiplier(v_l1_total);
+  v_l2_exp := public.calc_exp_multiplier(v_l2_total);
+  v_w1_change := greatest(1, round(v_player_change * v_w1_exp));
+  v_w2_change := greatest(1, round(v_player_change * v_w2_exp));
+  v_l1_change := greatest(1, round(v_player_change * v_l1_exp));
+  v_l2_change := greatest(1, round(v_player_change * v_l2_exp));
+
+  -- Insert match record (elo_change = winner1's gain for backward compat)
+  insert into public.matches (
+    winner_id, loser_id, winner_elo_before, loser_elo_before,
+    elo_change, loser_elo_change, recorded_by, challenge_id,
+    season_id, match_type, status
+  )
+  values (
+    p_winner1_id, p_loser1_id, v_w1_elo, v_l1_elo,
+    v_w1_change, v_l1_change, p_recorded_by, p_challenge_id,
+    v_season_id, 'doubles', 'confirmed'
+  )
+  returning id into v_match_id;
+
+  -- Insert match_players with per-player experience-scaled changes
+  insert into public.match_players (match_id, player_id, team, elo_before, elo_change) values
+    (v_match_id, p_winner1_id, 'winner', v_w1_elo, v_w1_change),
+    (v_match_id, p_winner2_id, 'winner', v_w2_elo, v_w2_change),
+    (v_match_id, p_loser1_id,  'loser',  v_l1_elo, -v_l1_change),
+    (v_match_id, p_loser2_id,  'loser',  v_l2_elo, -v_l2_change);
+
+  -- Update each player individually (different changes)
+  update public.profiles
+  set elo_rating = elo_rating + v_w1_change, wins = wins + 1,
+      total_wins = total_wins + 1, updated_at = now()
+  where id = p_winner1_id;
+
+  update public.profiles
+  set elo_rating = elo_rating + v_w2_change, wins = wins + 1,
+      total_wins = total_wins + 1, updated_at = now()
+  where id = p_winner2_id;
+
+  update public.profiles
+  set elo_rating = greatest(100, elo_rating - v_l1_change), losses = losses + 1,
+      total_losses = total_losses + 1, updated_at = now()
+  where id = p_loser1_id;
+
+  update public.profiles
+  set elo_rating = greatest(100, elo_rating - v_l2_change), losses = losses + 1,
+      total_losses = total_losses + 1, updated_at = now()
+  where id = p_loser2_id;
+
+  -- Complete challenge if applicable
+  if p_challenge_id is not null then
+    update public.challenges
+    set status = 'completed', completed_at = now()
+    where id = p_challenge_id;
+  end if;
+
+  return v_match_id;
+end;
+$$ language plpgsql security definer;
+
+-- ============================================
+-- REPLACE CREATE_PENDING_DOUBLES_MATCH RPC (experience-weighted)
+-- ============================================
+create or replace function public.create_pending_doubles_match(
+  p_winner1_id uuid,
+  p_winner2_id uuid,
+  p_loser1_id uuid,
+  p_loser2_id uuid,
+  p_recorded_by uuid,
+  p_challenge_id uuid default null
+) returns uuid as $$
+declare
+  v_w1_elo integer;
+  v_w2_elo integer;
+  v_l1_elo integer;
+  v_l2_elo integer;
+  v_w1_total integer;
+  v_w2_total integer;
+  v_l1_total integer;
+  v_l2_total integer;
+  v_team_winner_elo integer;
+  v_team_loser_elo integer;
+  v_expected float;
+  v_team_change integer;
+  v_player_change integer;
+  v_w1_exp float;
+  v_w2_exp float;
+  v_l1_exp float;
+  v_l2_exp float;
+  v_w1_change integer;
+  v_w2_change integer;
+  v_l1_change integer;
+  v_l2_change integer;
+  v_match_id uuid;
+  v_season_id uuid;
+begin
+  v_season_id := public.get_active_season_id();
+
+  -- Read current ratings + total matches (no lock, preview only)
+  select elo_rating, total_wins + total_losses into v_w1_elo, v_w1_total
+    from public.profiles where id = p_winner1_id;
+  select elo_rating, total_wins + total_losses into v_w2_elo, v_w2_total
+    from public.profiles where id = p_winner2_id;
+  select elo_rating, total_wins + total_losses into v_l1_elo, v_l1_total
+    from public.profiles where id = p_loser1_id;
+  select elo_rating, total_wins + total_losses into v_l2_elo, v_l2_total
+    from public.profiles where id = p_loser2_id;
+
+  v_team_winner_elo := v_w1_elo + v_w2_elo;
+  v_team_loser_elo := v_l1_elo + v_l2_elo;
+
+  v_expected := 1.0 / (1.0 + power(10.0, (v_team_loser_elo - v_team_winner_elo)::float / 400.0));
+  v_team_change := greatest(1, round(32 * (1.0 - v_expected)));
+  v_player_change := greatest(1, round(v_team_change::float / 2.0));
+
+  -- Per-player experience multipliers
+  v_w1_exp := public.calc_exp_multiplier(v_w1_total);
+  v_w2_exp := public.calc_exp_multiplier(v_w2_total);
+  v_l1_exp := public.calc_exp_multiplier(v_l1_total);
+  v_l2_exp := public.calc_exp_multiplier(v_l2_total);
+  v_w1_change := greatest(1, round(v_player_change * v_w1_exp));
+  v_w2_change := greatest(1, round(v_player_change * v_w2_exp));
+  v_l1_change := greatest(1, round(v_player_change * v_l1_exp));
+  v_l2_change := greatest(1, round(v_player_change * v_l2_exp));
+
+  -- Insert match record with pending status
+  insert into public.matches (
+    winner_id, loser_id, winner_elo_before, loser_elo_before,
+    elo_change, loser_elo_change, recorded_by, challenge_id,
+    status, season_id, match_type
+  )
+  values (
+    p_winner1_id, p_loser1_id, v_w1_elo, v_l1_elo,
+    v_w1_change, v_l1_change, p_recorded_by, p_challenge_id,
+    'pending', v_season_id, 'doubles'
+  )
+  returning id into v_match_id;
+
+  -- Insert match_players with per-player experience-scaled preview values
+  insert into public.match_players (match_id, player_id, team, elo_before, elo_change) values
+    (v_match_id, p_winner1_id, 'winner', v_w1_elo, v_w1_change),
+    (v_match_id, p_winner2_id, 'winner', v_w2_elo, v_w2_change),
+    (v_match_id, p_loser1_id,  'loser',  v_l1_elo, -v_l1_change),
+    (v_match_id, p_loser2_id,  'loser',  v_l2_elo, -v_l2_change);
+
+  return v_match_id;
+end;
+$$ language plpgsql security definer;


### PR DESCRIPTION
### Summary
- Scale Elo changes per-player based on total all-time match count: `min(1.4, 0.6 + total_matches / 30)`
- Newbies (0 games) are protected with 0.6x multiplier; veterans (24+ games) risk 1.4x — asymmetric per player
- Add `loser_elo_change` column to `matches` table so winner gain and loser loss are tracked independently
- Rewrite all 5 match RPC functions (`record_match`, `create_pending_match`, `confirm_match`, `record_doubles_match`, `create_pending_doubles_match`) with per-player experience scaling
- Update all UI components (previews, match cards, charts, stats) to display asymmetric Elo changes
- Old matches with `NULL` loser_elo_change fall back to `elo_change` — no backfill needed

### Files changed
- `supabase/migrations/011_experience_elo.sql` — schema + all RPC rewrites
- `lib/elo.ts` — `calculateExpMultiplier()`, asymmetric return types
- `lib/types/database.ts` — `loser_elo_change` on `Match`
- 7 components updated for asymmetric display

Closes #5
